### PR TITLE
Collision masking

### DIFF
--- a/include/aabb.h
+++ b/include/aabb.h
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <climits>
 #include <algorithm>
-#include <climits>
 
 namespace isect2d {
 

--- a/include/glm_vec.h
+++ b/include/glm_vec.h
@@ -1,12 +1,18 @@
 #pragma once
 
 #include "glm/glm.hpp"
+#include "glm/gtx/norm.hpp"
+#include <cmath>
 
 namespace isect2d {
 
 template<>
 inline glm::vec2 normalize(const glm::vec2& _v) {
     return glm::normalize(_v);
+}
+
+inline float distance2(const glm::vec2& _v0, const glm::vec2& _v1) {
+    return glm::distance2(_v0, _v1);
 }
 
 }

--- a/include/isect2d.h
+++ b/include/isect2d.h
@@ -11,7 +11,6 @@
 #include "aabb.h"
 #include "obb.h"
 
-
 namespace std {
     template <>
         struct hash<pair<int32_t, int32_t>> {
@@ -22,6 +21,7 @@ namespace std {
 }
 
 namespace isect2d {
+
 
 template<typename T>
 static constexpr const T clamp(T val, T min, T max) {
@@ -79,69 +79,69 @@ struct ISect2D {
         pairMap.assign(pairMap.size(), -1);
     }
 
-/*
- * Performs broadphase collision detection on _aabbs dividing the
- * screen size _resolution by _split on X and Y dimension Returns the
- * set of colliding pairs in the _aabbs container
- */
-   void intersect(const std::vector<AABB<V>>& _aabbs) {
+    /*
+     * Performs broadphase collision detection on _aabbs dividing the
+     * screen size _resolution by _split on X and Y dimension Returns the
+     * set of colliding pairs in the _aabbs container
+     */
+    void intersect(const std::vector<AABB<V>>& _aabbs) {
 
-      clear();
+        clear();
 
-      size_t index = 0;
-      for (const auto& aabb : _aabbs) {
-          i32 x1 = aabb.min.x / xpad;
-          i32 y1 = aabb.min.y / ypad;
-          i32 x2 = aabb.max.x / xpad + 1;
-          i32 y2 = aabb.max.y / ypad + 1;
+        size_t index = 0;
+        for (const auto& aabb : _aabbs) {
+            i32 x1 = aabb.min.x / xpad;
+            i32 y1 = aabb.min.y / ypad;
+            i32 x2 = aabb.max.x / xpad + 1;
+            i32 y2 = aabb.max.y / ypad + 1;
 
-          x1 = clamp(x1, i32(0), split_x-1);
-          y1 = clamp(y1, i32(0), split_y-1);
-          x2 = clamp(x2, i32(1), split_x);
-          y2 = clamp(y2, i32(1), split_y);
+            x1 = clamp(x1, i32(0), split_x-1);
+            y1 = clamp(y1, i32(0), split_y-1);
+            x2 = clamp(x2, i32(1), split_x);
+            y2 = clamp(y2, i32(1), split_y);
 
-          for (i32 y = y1; y < y2; y++) {
-              for (i32 x = x1; x < x2; x++) {
-                  gridAABBs[x + y * split_x].push_back(index);
-              }
-          }
+            for (i32 y = y1; y < y2; y++) {
+                for (i32 x = x1; x < x2; x++) {
+                    gridAABBs[x + y * split_x].push_back(index);
+                }
+            }
 
-          index++;
-      }
+            index++;
+        }
 
-      for (auto& v : gridAABBs) {
-          if (v.empty()) { continue; }
-          // check all items against each other
-          for (size_t j = 0; j < v.size()-1; ++j) {
-              const auto& a(_aabbs[v[j]]);
+        for (auto& v : gridAABBs) {
+            if (v.empty()) { continue; }
+            // check all items against each other
+            for (size_t j = 0; j < v.size()-1; ++j) {
+                const auto& a(_aabbs[v[j]]);
 
-              for (size_t k = j + 1; k < v.size(); ++k) {
-                  const auto& b(_aabbs[v[k]]);
+                for (size_t k = j + 1; k < v.size(); ++k) {
+                    const auto& b(_aabbs[v[k]]);
 
-                  if (a.intersect(b)) {
-                      size_t key = hash_key(hash_int(v[j])<<32 | hash_int(v[k]));
-                      key &= (pairMap.size()-1);
+                    if (a.intersect(b)) {
+                        size_t key = hash_key(hash_int(v[j])<<32 | hash_int(v[k]));
+                        key &= (pairMap.size()-1);
 
-                      int i = pairMap[key];
+                        int i = pairMap[key];
 
-                      while (i != -1) {
-                          if (pairs[i].first == v[j] && pairs[i].second == v[k]) {
-                              // found
-                              break;
-                          }
-                          i = pairs[i].next;
-                      }
+                        while (i != -1) {
+                            if (pairs[i].first == v[j] && pairs[i].second == v[k]) {
+                                // found
+                                break;
+                            }
+                            i = pairs[i].next;
+                        }
 
-                      if (i == -1) {
-                          pairs.push_back(Pair{v[j], v[k], pairMap[key]});
-                          pairMap[key] = pairs.size()-1;
-                      }
-                  }
-              }
-          }
-          v.clear();
-      }
-   }
+                        if (i == -1) {
+                            pairs.push_back(Pair{v[j], v[k], pairMap[key]});
+                            pairMap[key] = pairs.size()-1;
+                        }
+                    }
+                }
+            }
+            v.clear();
+        }
+    }
 
 private:
     // from fontstash

--- a/include/obb.h
+++ b/include/obb.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include "vec.h"
 
 namespace isect2d {
@@ -48,11 +47,11 @@ struct OBB {
         return -atan2(m_axes[1].x, m_axes[1].y);
     }
 
-    const std::array<V, 4>& getQuad() const {
+    const V* getQuad() const {
         return m_quad;
     }
 
-    const std::array<V, 2>& getAxes() const{
+    const V* getAxes() const{
         return m_axes;
     }
 
@@ -104,8 +103,8 @@ private:
     float m_height;
     V m_centroid;
 
-    std::array<V, 2> m_axes;
-    std::array<V, 4> m_quad;
+    V m_axes[2];
+    V m_quad[4];
 
 };
 
@@ -125,7 +124,7 @@ static V projectToAxis(const OBB<V>& _obb, const V& axis) {
     double min = inf;
     double max = -inf;
 
-    const std::array<V, 4>& p = _obb.getQuad();
+    const V* p = _obb.getQuad();
 
     for (int i = 0; i < 4; ++i) {
         double d = dot(p[i], axis);
@@ -138,7 +137,7 @@ static V projectToAxis(const OBB<V>& _obb, const V& axis) {
 }
 
 template<typename V>
-inline static bool axisCollide(const OBB<V>& _a, const OBB<V>& _b, const std::array<V, 2>& axes) {
+inline static bool axisCollide(const OBB<V>& _a, const OBB<V>& _b, const V* axes) {
     for (int i = 0; i < 2; ++i) {
         V aproj = projectToAxis(_a, axes[i]);
         V bproj = projectToAxis(_b, axes[i]);


### PR DESCRIPTION
Introducing collision masking, group and mask are 4 bytes integer where `0xffffffff` for the mask means collision threshold (where threshold is a distance) is enabled for all groups.
